### PR TITLE
ci: fix docker-compose.yml

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     container_name: iqbe-db
     restart: unless-stopped
     volumes:
-      - mariadb-data:/var/lib/mariadb/data
+      - mariadb-data:/var/lib/mysql
     env_file:
       - dev.env
     


### PR DESCRIPTION
`volumes`のマウント先をきちんと設定しないと永続化されないので，該当の箇所を修正

参考：https://qiita.com/snooow/items/04a84193fb6c7076e86f

Fixes #66