### PR TITLE
fix(frontend): Practiceにおいて、FilteringのCloseボタンを押すと開始されない問題 を修正

### DIFF
--- a/packages/frontend/src/components/PracticeSceneChanger.tsx
+++ b/packages/frontend/src/components/PracticeSceneChanger.tsx
@@ -189,7 +189,7 @@ export default function({
           apply={toFilter}
           opened={filtering}
           onOpen={filter.open}
-          onClose={!!quizzes ? filter.close : toFilter}
+          onClose={toFilter}
         />
         <PracticeQuitModal
           onJudge={(j) => stopQuiz(j)}


### PR DESCRIPTION
Fixes #182